### PR TITLE
waiting for completion of the process should be performed after reading from the process

### DIFF
--- a/src/main/java/ie/corballis/sox/Sox.java
+++ b/src/main/java/ie/corballis/sox/Sox.java
@@ -121,21 +121,22 @@ public class Sox {
         IOException errorDuringExecution = null;
         try {
             process = processBuilder.start();
-            process.waitFor();
             BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-            String line;
+            List<String> lines = new ArrayList<String>();
+            String currentLine;
+            while ((currentLine = reader.readLine()) != null) {
+                lines.add(currentLine);
+            }
+            process.waitFor();
             if (process.exitValue() != 0) {
-                while ((line = reader.readLine()) != null) {
+                for (String line : lines) {
                     logger.error(line);
                 }
-            }
-            else {
-                while ((line = reader.readLine()) != null) {
+            } else {
+                for (String line : lines) {
                     logger.debug(line);
                 }
             }
-
-
         } catch (IOException e) {
             errorDuringExecution = e;
             logger.error("Error while running Sox. {}", e.getMessage());


### PR DESCRIPTION
From Java doc:
>  java.lang
>
> Class Process
>
> Because some native platforms only provide limited buffer size for standard input and output streams, failure to promptly write the input stream or read the output stream of the subprocess may cause the subprocess to block, or even deadlock.

When sox produces too much output, executing the `waitFor` method without reading the output buffer leads to the complete filling of that buffer. It's necessary to read the output of the process first.
