### PR TITLE
added ulaw file format

### DIFF
--- a/src/main/java/ie/corballis/sox/AudioFileFormat.java
+++ b/src/main/java/ie/corballis/sox/AudioFileFormat.java
@@ -469,6 +469,12 @@ public enum AudioFileFormat {
             return "ul";
         }
     },
+    ULAW {
+        @Override
+        public String toString() {
+            return "ulaw";
+        }
+    },
     UW {
         @Override
         public String toString() {


### PR DESCRIPTION
passing "filename.ulaw" in output filename throws error FAIL_FORMAT.
This fixes the issue.